### PR TITLE
fix(index): make containers of a elements span instead of button

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -88,9 +88,9 @@
             <div class="mdl-cell mdl-cell--6-col-desktop mdl-cell--12-col-tablet mdl-cell--12-col-phone">
                 <h4 class="mt3">Angular Mobile Toolkit</h4>
                 <h5 class="mt1 mb3 mr0 tagline">All the tools and techniques to build high-performance mobile apps</h5>
-                <button style="margin-bottom: 16px;" class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--primary">
+                <span style="margin-bottom: 16px;" class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--primary">
                   <a href="https://github.com/angular/mobile-toolkit" class="mdl-typography--font-regular"> Get Started </a>
-                </button>
+                </span>
             </div>
           </section>
         </header>
@@ -117,9 +117,9 @@
           <!--</div>-->
 
           <div class="mdl-cell mdl-cell--12-col-desktop center">
-            <button class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent">
+            <span class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent">
               <a href="https://github.com/angular/mobile-toolkit" class="mdl-typography--font-regular"> Get Started </a>
-            </button>
+            </span>
           </div>
         </section>
 


### PR DESCRIPTION
In Firefox, any anchor elements that were inside <button> elements
would not work. Now they're inside <span>s.

This has already been pushed to prod.